### PR TITLE
Update dataprep_gc.py

### DIFF
--- a/tutorials/tutorial_1/containers/data-prep/dataprep_gc.py
+++ b/tutorials/tutorial_1/containers/data-prep/dataprep_gc.py
@@ -32,7 +32,7 @@ def dataset_dcm_to_jpg(dataset_df):
 		if not os.path.exists(class_folder):
 			os.makedirs(class_folder)
 		image.save('/'.join([class_folder, jpg_file_name]))
-		dataset_df.loc[idx, 'JPG file'] = '/'.join([ground_truth, jpg_file_name])
+		dataset_df.loc[idx, 'JPG_file'] = '/'.join([ground_truth, jpg_file_name])
 
 	return dataset_df
 


### PR DESCRIPTION
Fix inconsistent column naming in output dataset. 'JPG file' to 'JPG_file' to avoid duplicate fields when running the code.

Results before:

<img width="328" alt="Screenshot 2025-06-02 at 12 21 15 PM" src="https://github.com/user-attachments/assets/141dc58f-0a40-486c-80c5-af037e4ccfc7" />
<img width="579" alt="Screenshot 2025-06-02 at 12 21 28 PM" src="https://github.com/user-attachments/assets/cda3fa57-22ea-491b-8b6f-da5cfd09c8d7" />
.


Results after:

<img width="669" alt="Screenshot 2025-06-02 at 12 25 06 PM" src="https://github.com/user-attachments/assets/cbbc32c3-4538-4ca2-8273-5a1031508c33" />
<img width="288" alt="Screenshot 2025-06-02 at 12 25 14 PM" src="https://github.com/user-attachments/assets/56e296b0-106a-4d1b-b5c8-e2ffaed2ca27" />



